### PR TITLE
fix: 거래 종료로 마켓 코드에서 라이트 코인 삭제

### DIFF
--- a/backend/module-domain/src/main/java/com/project/cs/cryptocurrency/feignclient/Market.java
+++ b/backend/module-domain/src/main/java/com/project/cs/cryptocurrency/feignclient/Market.java
@@ -8,7 +8,6 @@ public enum Market {
     이더리움("Ethereum", "KRW-ETH"),
     네오("NEO", "KRW-NEO"),
     메탈("Metal", "KRW-MTL"),
-    라이트코인("Litecoin", "KRW-LTC"),
     리플("Ripple", "KRW-XRP"),
     이더리움클래식("Ethereum Classic", "KRW-ETC"),
     오미세고("OmiseGo", "KRW-OMG"),


### PR DESCRIPTION
closed #45 